### PR TITLE
extract_property replace None option

### DIFF
--- a/src/obslib/obslib.py
+++ b/src/obslib/obslib.py
@@ -289,9 +289,12 @@ class Session:
 
         return value
 
-def extract_property(source, key, *, default=None, optional=False):
+def extract_property(source, key, *, default=None, optional=False, replace_none=False):
     validate(isinstance(source, dict), "Invalid source passed to extract_property. Must be a dict")
     validate(isinstance(key, str), "Invalid key passed to extract_property")
+    validate(isinstance(optional, bool), "Invalid optional parameter to extract_property")
+    validate(isinstance(replace_none, bool), "Invalid replace_none parameter to extract_property")
+
 
     if key not in source:
         # Raise exception is the key isn't present, but required
@@ -303,7 +306,7 @@ def extract_property(source, key, *, default=None, optional=False):
 
     # Retrieve value
     val = source.pop(key)
-    if val is None:
+    if val is None and replace_none:
         return default
 
     return val

--- a/src/tests/test_extract_property.py
+++ b/src/tests/test_extract_property.py
@@ -31,12 +31,40 @@ class TestExtractProperty:
         with pytest.raises(KeyError):
             value = obslib.extract_property(source, "prop2")
 
-    def test_optional_value(self):
+    def test_optional_value1(self):
         source = {
             "prop1": 1
         }
 
         value = obslib.extract_property(source, "prop2", optional=True)
 
-        assert(value is None)
+        assert value is None
+
+    def test_optional_value2(self):
+        source = {
+            "prop1": 1
+        }
+
+        with pytest.raises(KeyError):
+            value = obslib.extract_property(source, "prop2", optional=False)
+
+            assert value is None
+
+    def test_replace_none1(self):
+        source = {
+            "prop1": None
+        }
+
+        value = obslib.extract_property(source, "prop1", default=5, replace_none=False)
+
+        assert value is None
+
+    def test_replace_none2(self):
+        source = {
+            "prop1": None
+        }
+
+        value = obslib.extract_property(source, "prop1", default=5, replace_none=True)
+
+        assert value == 5
 


### PR DESCRIPTION
Option to replace None on extract_property, with the default being not
to.
Previous behavior was to replace None unconditionally when the value is
None.
