### PR TITLE
Rename optional parameter on extract_property

### DIFF
--- a/src/obslib/obslib.py
+++ b/src/obslib/obslib.py
@@ -292,21 +292,20 @@ class Session:
 
         return value
 
-def extract_property(source, key, *, default=None, optional=False, replace_none=False, remove=True):
+def extract_property(source, key, *, default=None, replace_missing=False, replace_none=False, remove=True):
     validate(isinstance(source, dict), "Invalid source passed to extract_property. Must be a dict")
     validate(isinstance(key, str), "Invalid key passed to extract_property")
-    validate(isinstance(optional, bool), "Invalid optional parameter to extract_property")
+    validate(isinstance(replace_missing, bool), "Invalid value for replace_missing on extract_property")
     validate(isinstance(replace_none, bool), "Invalid replace_none parameter to extract_property")
     validate(isinstance(remove, bool), "Invalid remove parameter to extract_property")
 
 
     if key not in source:
-        # Raise exception is the key isn't present, but required
-        if not optional:
-            raise KeyError(f'Missing key "{key}" in source or value is null')
+        if replace_missing:
+            return default
 
-        # If the key is not present, return the default
-        return default
+        # No replace for missing value, so raise error
+        raise KeyError(f'Missing key "{key}" in source or value is null')
 
     # Retrieve value
     if remove:

--- a/src/tests/test_extract_property.py
+++ b/src/tests/test_extract_property.py
@@ -36,7 +36,7 @@ class TestExtractProperty:
             "prop1": 1
         }
 
-        value = obslib.extract_property(source, "prop2", optional=True)
+        value = obslib.extract_property(source, "prop2", replace_missing=True)
 
         assert value is None
 
@@ -46,7 +46,7 @@ class TestExtractProperty:
         }
 
         with pytest.raises(KeyError):
-            value = obslib.extract_property(source, "prop2", optional=False)
+            value = obslib.extract_property(source, "prop2", replace_missing=False)
 
             assert value is None
 


### PR DESCRIPTION
Renamed 'optional' to replace_missing to make the behaviour clearer
