### PR TITLE
extract_property parameter - on_none + on_missing

### DIFF
--- a/src/obslib/__init__.py
+++ b/src/obslib/__init__.py
@@ -5,6 +5,7 @@ from .obslib import parse_bool
 from .obslib import eval_vars
 from .obslib import Session
 from .obslib import extract_property
+from .obslib import Default
 
 from .exception import *
 

--- a/src/obslib/obslib.py
+++ b/src/obslib/obslib.py
@@ -9,6 +9,10 @@ from jinja2.meta import find_undeclared_variables
 
 logger = logging.getLogger(__name__)
 
+class Default:
+    pass
+
+
 def validate(val, message, extype=exception.OBSValidationException):
     """
     Convenience method for raising an exception on validation failure
@@ -292,17 +296,15 @@ class Session:
 
         return value
 
-def extract_property(source, key, *, default=None, replace_missing=False, replace_none=False, remove=True):
+def extract_property(source, key, *, on_missing=Default, on_none=Default, remove=True):
     validate(isinstance(source, dict), "Invalid source passed to extract_property. Must be a dict")
     validate(isinstance(key, str), "Invalid key passed to extract_property")
-    validate(isinstance(replace_missing, bool), "Invalid value for replace_missing on extract_property")
-    validate(isinstance(replace_none, bool), "Invalid replace_none parameter to extract_property")
     validate(isinstance(remove, bool), "Invalid remove parameter to extract_property")
 
 
     if key not in source:
-        if replace_missing:
-            return default
+        if on_missing != Default:
+            return on_missing
 
         # No replace for missing value, so raise error
         raise KeyError(f'Missing key "{key}" in source or value is null')
@@ -313,8 +315,8 @@ def extract_property(source, key, *, default=None, replace_missing=False, replac
     else:
         val = source[key]
 
-    if val is None and replace_none:
-        return default
+    if val is None and on_none != Default:
+        return on_none
 
     return val
 

--- a/src/tests/test_extract_property.py
+++ b/src/tests/test_extract_property.py
@@ -36,7 +36,7 @@ class TestExtractProperty:
             "prop1": 1
         }
 
-        value = obslib.extract_property(source, "prop2", replace_missing=True)
+        value = obslib.extract_property(source, "prop2", on_missing=None)
 
         assert value is None
 
@@ -46,25 +46,35 @@ class TestExtractProperty:
         }
 
         with pytest.raises(KeyError):
-            value = obslib.extract_property(source, "prop2", replace_missing=False)
+            value = obslib.extract_property(source, "prop2")
 
             assert value is None
 
-    def test_replace_none1(self):
+    def test_optional_value3(self):
+        source = {
+            "prop1": 1
+        }
+
+        with pytest.raises(KeyError):
+            value = obslib.extract_property(source, "prop2", on_missing=obslib.Default)
+
+            assert value is None
+
+    def test_on_none1(self):
         source = {
             "prop1": None
         }
 
-        value = obslib.extract_property(source, "prop1", default=5, replace_none=False)
+        value = obslib.extract_property(source, "prop1", on_missing=5)
 
         assert value is None
 
-    def test_replace_none2(self):
+    def test_on_none2(self):
         source = {
             "prop1": None
         }
 
-        value = obslib.extract_property(source, "prop1", default=5, replace_none=True)
+        value = obslib.extract_property(source, "prop1", on_missing=6, on_none=5)
 
         assert value == 5
 


### PR DESCRIPTION
Change signature for extract_property to define behaviour for on_missing
and on_none
Allows None to be supplied to on_missing or on_none via using the
'Default' class for comparison.
