### PR TITLE
Parameter chg for Session.resolve to on_none

### DIFF
--- a/src/obslib/obslib.py
+++ b/src/obslib/obslib.py
@@ -281,7 +281,7 @@ class Session:
         self._environment = environment
         self.vars = template_vars
 
-    def resolve(self, value, types=None, *, template=True, depth=-1, default=None):
+    def resolve(self, value, types=None, *, template=True, depth=-1, on_none=Default):
         validate(isinstance(template, bool), "Invalid value for template passed to resolve")
         validate(isinstance(depth, int), "Invalid value for depth passed to resolve")
 
@@ -291,8 +291,8 @@ class Session:
         if types is not None:
             value = coerce_value(value, types)
 
-        if value is None:
-            return default
+        if value is None and on_none != Default:
+            return on_none
 
         return value
 

--- a/src/tests/test_session.py
+++ b/src/tests/test_session.py
@@ -88,7 +88,7 @@ class TestSession:
 
         session = obslib.Session({})
 
-        result = session.resolve(source_val, types=(list, type(None)), default=5)
+        result = session.resolve(source_val, types=(list, type(None)), on_none=5)
 
         assert result == 5
 


### PR DESCRIPTION
Change parameters for Session.resolve to match extract_property
Value to supply when none is encountered renamed from default to on_none
